### PR TITLE
Add parameter to ignore HTTPS errors (feature)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 1.4.0 - April 27, 2020
+
+- feat: allow for ignoring HTTPS errors
+
 # 1.3.0 - April 27, 2020
 
 - feat: MacOS support

--- a/action.yml
+++ b/action.yml
@@ -27,3 +27,7 @@ inputs:
     required: false
     description: "The screenshot name if you do not want the default timestamp"
     default: false
+  ignoreHTTPSErrors:
+    required: false
+    description: "Whether Puppeteer should ignore HTTPS errors"
+    default: false

--- a/index.js
+++ b/index.js
@@ -41,6 +41,7 @@ function getChromePath() {
     const width = parseInt(core.getInput("width"));
     const height = parseInt(core.getInput("height"));
     const fullPage = core.getInput("fullPage") === "true";
+    const ignoreHTTPSErrors = core.getInput("ignoreHTTPSErrors") === "true";
     const screenshotName =
       core.getInput("screenshotName") !== "false"
         ? core.getInput("screenshotName")
@@ -49,7 +50,7 @@ function getChromePath() {
     const browser = await puppeteer.launch({
       executablePath: getChromePath(),
       defaultViewport: { width, height },
-      ignoreHTTPSErrors: true
+      ignoreHTTPSErrors: ignoreHTTPSErrors
     });
     const page = await browser.newPage();
     await page.goto(url, {

--- a/index.js
+++ b/index.js
@@ -50,7 +50,7 @@ function getChromePath() {
     const browser = await puppeteer.launch({
       executablePath: getChromePath(),
       defaultViewport: { width, height },
-      ignoreHTTPSErrors: ignoreHTTPSErrors
+      ignoreHTTPSErrors: ignoreHTTPSErrors,
     });
     const page = await browser.newPage();
     await page.goto(url, {

--- a/index.js
+++ b/index.js
@@ -49,6 +49,7 @@ function getChromePath() {
     const browser = await puppeteer.launch({
       executablePath: getChromePath(),
       defaultViewport: { width, height },
+      ignoreHTTPSErrors: true
     });
     const page = await browser.newPage();
     await page.goto(url, {


### PR DESCRIPTION
Makes is possible to use tell Puppeteer to ignore HTTPs errors. Intended to enable screenshotting of local dev with self-signed certs (e.g. `create-react-app start` => Take screenshot)